### PR TITLE
Dimnames

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,10 @@
 
 - As announced, the argument `show_other` of `sv_importance()` has been removed.
 
+## Small changes
+
+- Slightly less picky checks on `S_inter`.
+
 # shapviz 0.6.0
 
 ## Change in defaults

--- a/R/shapviz.R
+++ b/R/shapviz.R
@@ -86,11 +86,12 @@ shapviz.matrix = function(object, X, baseline = 0, collapse = NULL,
     }
   }
   .input_checks(object = object, X = X, baseline = baseline, S_inter = S_inter)
+  nms <- colnames(object)
   out <- list(
     S = object,
-    X = as.data.frame(X)[colnames(object)],
+    X = as.data.frame(X)[nms],
     baseline = baseline,
-    S_inter = S_inter
+    S_inter = S_inter[, nms, nms, drop = FALSE]
   )
   class(out) <- "shapviz"
   out
@@ -361,9 +362,9 @@ shapviz.H2OModel = function(object, X_pred, X = as.data.frame(X_pred),
         dim(S_inter) == c(dim(object), ncol(object)),
       "Dimensions 2 and 3 of 'S_inter' must have names" =
         !is.null(nms[[2L]]) && !is.null(nms[[3L]]),
-      "Dimnames 2 and 3 of 'S_inter' must be consistent" = nms[[2L]] == nms[[3L]],
+      "Dimnames 2 and 3 of 'S_inter' must be equal" = nms[[2L]] == nms[[3L]],
       "Dimnames of 'S_inter' must be consistent with those of 'object'" =
-        nms[[2L]] == colnames(object),
+        all(colnames(object) %in% nms[[2L]]),
       "No missing SHAP interaction values allowed" = !anyNA(S_inter)
       # "SHAP interactions must sum up to SHAP values" =
       #   max(abs(object - apply(S_inter, 1:2, FUN = sum))) <= 1e-4,

--- a/R/shapviz.R
+++ b/R/shapviz.R
@@ -86,13 +86,16 @@ shapviz.matrix = function(object, X, baseline = 0, collapse = NULL,
     }
   }
   .input_checks(object = object, X = X, baseline = baseline, S_inter = S_inter)
+
+  # Select and align columns according to SHAP matrix ('object')
   nms <- colnames(object)
-  out <- list(
-    S = object,
-    X = as.data.frame(X)[nms],
-    baseline = baseline,
-    S_inter = S_inter[, nms, nms, drop = FALSE]
-  )
+  X <- as.data.frame(X)[nms]
+  if (!is.null(S_inter)) {
+    S_inter <- S_inter[, nms, nms, drop = FALSE]
+  }
+
+  # Organize output
+  out <- list(S = object, X = X, baseline = baseline, S_inter = S_inter)
   class(out) <- "shapviz"
   out
 }

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -8,7 +8,7 @@ test_that("get_* functions work", {
   expect_equal(X, get_feature_values(shp))
 })
 
-test_that("dim, nrow, ncol, colnames  work", {
+test_that("dim, nrow, ncol, colnames work", {
   expect_equal(dim(shp), c(2L, 2L))
   expect_equal(nrow(shp), 2L)
   expect_equal(ncol(shp), 2L)
@@ -101,6 +101,13 @@ test_that("shapviz accepts correct S_inter", {
     )
   )
   expect_silent(
+    shapviz(S, X = X, baseline = 4, S_inter = S_inter[, c("y", "x"), c("y", "x")])
+  )
+  expect_identical(
+    shapviz(S, X = X, baseline = 4, S_inter = S_inter[, c("y", "x"), c("y", "x")]),
+    S_inter
+  )
+  expect_silent(
     shapviz(
       S[, "x", drop = FALSE],
       X = X["x"],
@@ -113,9 +120,16 @@ test_that("shapviz accepts correct S_inter", {
   expect_equal(dim(shp_inter[1, "x"]$S_inter), c(1L, 1L, 1L))
 })
 
-test_that("shapviz does not accept bad S_inter", {
+test_that("shapviz does not accept S_inter with bad colnames", {
   S_inter_noname <- array(c(1, -1, 0, 0, 0, 0, -1, 1), dim = c(2L, 2L, 2L))
   expect_error(shapviz(S, X = X, baseline = 4, S_inter = S_inter_noname))
+
+  S_inter_badname <- S_inter_noname
+  dimnames(S_inter_badname) <- list(NULL, c("x", "z"), c("x", "z"))
+  expect_error(shapviz(S, X = X, baseline = 4, S_inter = S_inter_badname))
+
+  dimnames(S_inter_badname) <- list(NULL, c("x", "y"), c("y", "x"))
+  expect_error(shapviz(S, X = X, baseline = 4, S_inter = S_inter_badname))
 })
 
 # More tests on interactions

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -104,7 +104,9 @@ test_that("shapviz accepts correct S_inter", {
     shapviz(S, X = X, baseline = 4, S_inter = S_inter[, c("y", "x"), c("y", "x")])
   )
   expect_identical(
-    shapviz(S, X = X, baseline = 4, S_inter = S_inter[, c("y", "x"), c("y", "x")]),
+    get_shap_interactions(
+      shapviz(S, X = X, baseline = 4, S_inter = S_inter[, c("y", "x"), c("y", "x")])
+    ),
     S_inter
   )
   expect_silent(


### PR DESCRIPTION
This PR

- relaxes the input checks on SHAP interactions: Their dimensions 2 and 3 still need to have the same column names, but they simply have to be a superset of the colnames of the SHAP matrix (instead of being identical). 
- ~~On construction of the "shapviz" object, rownames of the SHAP matrix (usually NULL) are translated to those of the feature data and the SHAP interactions. This makes subsetting of the "shapviz" object more safe.~~