### PR TITLE
Add stricter mshapviz interface

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # shapviz 0.9.3
 
+## User-visible changes
+
+- `mshapviz()` is more strict when combining multiple "shapviz" objects. These now need to have identical column names.
+
 ## Other changes
 
 - Re-activate all unit tests.

--- a/R/shapviz.R
+++ b/R/shapviz.R
@@ -462,9 +462,9 @@ shapviz.H2OModel = function(object, X_pred, X = as.data.frame(X_pred),
   )
 }
 
-#' Concatenates "shapviz" Objects
+#' Combines compatible "shapviz" Objects
 #'
-#' This function combines a list of "shapviz" objects to an object of class
+#' This function combines a list of compatible "shapviz" objects to an object of class
 #' "mshapviz". The elements can be named.
 #'
 #' @param object List of "shapviz" objects to be concatenated.
@@ -479,10 +479,21 @@ shapviz.H2OModel = function(object, X_pred, X = as.data.frame(X_pred),
 #' s <- mshapviz(c(shp1 = s1, shp2 = s2))
 #' s
 mshapviz <- function(object, ...) {
-  stopifnot("'object' must be a list of 'shapviz' objects" = is.list(object))
+  stopifnot("'object' must be a list" = is.list(object))
   if (!all(vapply(object, is.shapviz, FUN.VALUE = logical(1)))) {
     stop("Must pass list of 'shapviz' objects")
   }
+  nms <- lapply(object, colnames)
+  if (!all(vapply(nms, identical, y = nms[[1L]], FUN.VALUE = logical(1)))) {
+    stop("'shapviz' objects need to have identical column names")
+  }
+  # Plot methods using interactions and do.call(rbind, ...) will fail, other plots are ok
+  # inter <- vapply(
+  #   object, function(x) is.null(get_shap_interactions(x)), FUN.VALUE = logical(1)
+  # )
+  # if (!(all(inter) || !any(inter))) {
+  #   stop("Some 'shapviz' objects have SHAP interactions, some not.")
+  # }
   structure(object, class = "mshapviz")
 }
 

--- a/man/mshapviz.Rd
+++ b/man/mshapviz.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/shapviz.R
 \name{mshapviz}
 \alias{mshapviz}
-\title{Concatenates "shapviz" Objects}
+\title{Combines compatible "shapviz" Objects}
 \usage{
 mshapviz(object, ...)
 }
@@ -15,7 +15,7 @@ mshapviz(object, ...)
 A "mshapviz" object.
 }
 \description{
-This function combines a list of "shapviz" objects to an object of class
+This function combines a list of compatible "shapviz" objects to an object of class
 "mshapviz". The elements can be named.
 }
 \examples{

--- a/tests/testthat/test-plots-mshapviz.R
+++ b/tests/testthat/test-plots-mshapviz.R
@@ -55,6 +55,18 @@ test_that("dependence plots work for interactions = TRUE", {
   )
 })
 
+test_that("shapviz objects w/o interactions can be combined and used for most things", {
+  x_temp1 <- shapviz(fit, X_pred = dtrain, X = iris[, -1L], interactions = TRUE)
+  x_temp2 <- shapviz(fit, X_pred = dtrain, X = iris[, -1L])
+  expect_no_error(x_inter_m <- c(x_temp1, x_temp2))
+  expect_error(do.call(rbind, x_inter_m))
+  expect_error(sv_interaction(x_inter_m))
+  expect_s3_class(sv_importance(x_inter_m), "ggplot")
+  expect_s3_class(sv_dependence(x_inter_m, "Sepal.Width"), "patchwork")
+  expect_error(sv_dependence(x_inter_m, "Sepal.Width", interactions = TRUE))
+  expect_equal(sapply(get_shap_interactions(x_inter_m), is.null), c(FALSE, TRUE))
+})
+
 test_that("main effect plots equal case color_var = v", {
   expect_equal(
     sv_dependence(x_inter, "Petal.Length", color_var = NULL, interactions = TRUE),
@@ -118,3 +130,4 @@ test_that("sv_dependence() does not work with multiple v", {
   expect_error(sv_dependence2D(x, x = c("Species", "Sepal.Width"), y = "Petal.Width"))
   expect_error(sv_dependence2D(x, x = "Petal.Width", y = c("Species", "Sepal.Width")))
 })
+

--- a/tests/testthat/test-plots-shapviz.R
+++ b/tests/testthat/test-plots-shapviz.R
@@ -1,173 +1,173 @@
-# dtrain <- xgboost::xgb.DMatrix(data.matrix(iris[, -1L]), label = iris[, 1L])
-# fit <- xgboost::xgb.train(params = list(nthread = 1L), data = dtrain, nrounds = 1L)
-# x <- shapviz(fit, X_pred = dtrain, X = iris[, -1L])
-#
-# test_that("plots work for basic example", {
-#   expect_s3_class(sv_waterfall(x, 2), "ggplot")
-#   suppressMessages(expect_s3_class(sv_waterfall(x, 2:3), "ggplot"))
-#   expect_s3_class(sv_force(x, 2), "ggplot")
-#   suppressMessages(expect_s3_class(sv_force(x, 2:3), "ggplot"))
-#   expect_s3_class(sv_importance(x), "ggplot")
-#   expect_s3_class(sv_importance(x, show_numbers = TRUE), "ggplot")
-#   expect_s3_class(sv_importance(x, kind = "beeswarm"), "ggplot")
-#   expect_s3_class(sv_dependence(x, "Petal.Length"), "ggplot")
-#   expect_s3_class(sv_dependence(x, c("Petal.Length", "Species")), "patchwork")
-#   expect_s3_class(
-#     sv_dependence(
-#       x,
-#       "Petal.Length",
-#       color_var = c("Petal.Length", "Species"),
-#       jitter_width = c(0, 0.1),
-#     ),
-#     "patchwork"
-#   )
-#   expect_s3_class(sv_dependence2D(x, x = "Petal.Length", y = "Species"), "ggplot")
-#   expect_s3_class(
-#     sv_dependence2D(x, x = "Petal.Length", y = c("Species", "Petal.Width")), "patchwork"
-#   )
-#   expect_s3_class(
-#     sv_dependence2D(x, x = c("Petal.Length", "Petal.Width"), y = "Species"), "patchwork"
-#   )
-#   expect_s3_class(
-#     sv_dependence2D(
-#       x, x = c("Petal.Length", "Petal.Width"), y = c("Species", "Sepal.Width")
-#     ),
-#     "patchwork"
-#   )
-# })
-#
-# test_that("using 'max_display' gives no error", {
-#   expect_s3_class(sv_waterfall(x, 2, max_display = 2L), "ggplot")
-#   suppressMessages(expect_s3_class(sv_waterfall(x, 2:10, max_display = 2L), "ggplot"))
-#   expect_s3_class(sv_force(x, 2, max_display = 2L), "ggplot")
-#   suppressMessages(expect_s3_class(sv_force(x, 2:10, max_display = 2L), "ggplot"))
-#   expect_s3_class(sv_importance(x, max_display = 2L), "ggplot")
-#   expect_s3_class(sv_importance(x, max_display = 2L, show_numbers = TRUE), "ggplot")
-# })
-#
-# # SHAP interactions
-# x_inter <- shapviz(fit, X_pred = dtrain, X = iris[, -1L], interactions = TRUE)
-#
-# test_that("dependence plots work for interactions = TRUE", {
-#   expect_s3_class(
-#     sv_dependence(x_inter, v = "Petal.Length", interactions = TRUE),
-#     "ggplot"
-#   )
-#   expect_s3_class(
-#     sv_dependence(x_inter, v = c("Petal.Length", "Species"), interactions = TRUE),
-#     "patchwork"
-#   )
-#   expect_s3_class(
-#     sv_dependence(
-#       x_inter,
-#       v = "Species",
-#       color_var = c("Petal.Length", "Species"),
-#       interactions = TRUE
-#     ),
-#     "patchwork"
-#   )
-#
-#   expect_s3_class(
-#     sv_dependence(x_inter, "Petal.Length", color_var = "Species", interactions = TRUE),
-#     "ggplot"
-#   )
-#   expect_s3_class(
-#     sv_dependence(
-#       x_inter,
-#       v = c("Petal.Length", "Species"),
-#       color_var = "Species",
-#       interactions = TRUE
-#     ),
-#     "patchwork"
-#   )
-#
-#   expect_s3_class(
-#     sv_dependence2D(x_inter, x = "Petal.Length", y = "Species", interactions = TRUE),
-#     "ggplot"
-#   )
-#   expect_s3_class(
-#     sv_dependence2D(
-#       x_inter, x = "Petal.Length", y = c("Species", "Petal.Width"), interactions = TRUE
-#     ),
-#     "patchwork"
-#   )
-#   expect_s3_class(
-#     sv_dependence2D(
-#       x_inter, x = c("Petal.Length", "Petal.Width"), y = "Species", interactions = TRUE
-#     ),
-#     "patchwork"
-#   )
-#   expect_s3_class(
-#     sv_dependence2D(
-#       x_inter,
-#       x = c("Petal.Length", "Petal.Width"),
-#       y = c("Species", "Sepal.Width"),
-#       interactions = TRUE
-#     ),
-#     "patchwork"
-#   )
-# })
-#
-# test_that("main effect plots equal case color_var = v", {
-#   expect_equal(
-#     sv_dependence(x_inter, "Petal.Length", color_var = NULL, interactions = TRUE),
-#     sv_dependence(
-#       x_inter, "Petal.Length", color_var = "Petal.Length", interactions = TRUE
-#     )
-#   )
-# })
-#
-# test_that("Interaction plots provide ggplot object", {
-#   expect_s3_class(sv_interaction(x_inter), "ggplot")
-# })
-#
-# # Non-standard name
-# ir <- iris
-# ir["strange name"] <- ir$Sepal.Width * ir$Petal.Length
-# dtrain <- xgboost::xgb.DMatrix(data.matrix(ir[, -1L]), label = ir[, 1L])
-# fit <- xgboost::xgb.train(params = list(nthread = 1L), data = dtrain, nrounds = 1L)
-# x <- shapviz(fit, X_pred = dtrain, X = ir[, -1L])
-#
-# test_that("plots work for non-syntactic column names", {
-#   expect_s3_class(sv_waterfall(x, 2), "ggplot")
-#   expect_s3_class(sv_force(x, 2), "ggplot")
-#   expect_s3_class(sv_importance(x), "ggplot")
-#   expect_s3_class(sv_importance(x, show_numbers = TRUE), "ggplot")
-#   expect_s3_class(sv_importance(x, max_display = 2, kind = "beeswarm"), "ggplot")
-#   expect_s3_class(sv_importance(x, kind = "beeswarm"), "ggplot")
-#   expect_s3_class(sv_dependence(x, "strange name"), "ggplot")
-#   expect_s3_class(
-#     sv_dependence(x, "Petal.Length", color_var = "strange name"), "ggplot"
-#   )
-#   expect_s3_class(
-#     sv_dependence2D(x, x = "Petal.Length", y = "strange name"), "ggplot"
-#   )
-# })
-#
-# # Miscellaneous tests
-# test_that("there are no default sv_*() methods", {
-#   for (f in c(
-#     sv_dependence,
-#     sv_dependence2D,
-#     sv_importance,
-#     sv_force,
-#     sv_waterfall,
-#     sv_interaction
-#   )) {
-#     expect_error(f(1))
-#   }
-# })
-#
-# test_that("sv_importance() and sv_interaction() and kind = 'no' gives numeric output", {
-#   X_pred <- data.matrix(iris[, -1L])
-#   dtrain <- xgboost::xgb.DMatrix(X_pred, label = iris[, 1L])
-#   fit <- xgboost::xgb.train(params = list(nthread = 1L), data = dtrain, nrounds = 1L)
-#   x <- shapviz(fit, X_pred = X_pred, interactions = TRUE)
-#
-#   imp <- sv_importance(x, kind = "no")
-#   expect_true(is.numeric(imp) && length(imp) == ncol(X_pred))
-#
-#   inter <- sv_interaction(x, kind = "no")
-#   expect_true(is.numeric(inter) && all(dim(inter) == rep(ncol(X_pred), 2L)))
-# })
-#
+dtrain <- xgboost::xgb.DMatrix(data.matrix(iris[, -1L]), label = iris[, 1L])
+fit <- xgboost::xgb.train(params = list(nthread = 1L), data = dtrain, nrounds = 1L)
+x <- shapviz(fit, X_pred = dtrain, X = iris[, -1L])
+
+test_that("plots work for basic example", {
+  expect_s3_class(sv_waterfall(x, 2), "ggplot")
+  suppressMessages(expect_s3_class(sv_waterfall(x, 2:3), "ggplot"))
+  expect_s3_class(sv_force(x, 2), "ggplot")
+  suppressMessages(expect_s3_class(sv_force(x, 2:3), "ggplot"))
+  expect_s3_class(sv_importance(x), "ggplot")
+  expect_s3_class(sv_importance(x, show_numbers = TRUE), "ggplot")
+  expect_s3_class(sv_importance(x, kind = "beeswarm"), "ggplot")
+  expect_s3_class(sv_dependence(x, "Petal.Length"), "ggplot")
+  expect_s3_class(sv_dependence(x, c("Petal.Length", "Species")), "patchwork")
+  expect_s3_class(
+    sv_dependence(
+      x,
+      "Petal.Length",
+      color_var = c("Petal.Length", "Species"),
+      jitter_width = c(0, 0.1),
+    ),
+    "patchwork"
+  )
+  expect_s3_class(sv_dependence2D(x, x = "Petal.Length", y = "Species"), "ggplot")
+  expect_s3_class(
+    sv_dependence2D(x, x = "Petal.Length", y = c("Species", "Petal.Width")), "patchwork"
+  )
+  expect_s3_class(
+    sv_dependence2D(x, x = c("Petal.Length", "Petal.Width"), y = "Species"), "patchwork"
+  )
+  expect_s3_class(
+    sv_dependence2D(
+      x, x = c("Petal.Length", "Petal.Width"), y = c("Species", "Sepal.Width")
+    ),
+    "patchwork"
+  )
+})
+
+test_that("using 'max_display' gives no error", {
+  expect_s3_class(sv_waterfall(x, 2, max_display = 2L), "ggplot")
+  suppressMessages(expect_s3_class(sv_waterfall(x, 2:10, max_display = 2L), "ggplot"))
+  expect_s3_class(sv_force(x, 2, max_display = 2L), "ggplot")
+  suppressMessages(expect_s3_class(sv_force(x, 2:10, max_display = 2L), "ggplot"))
+  expect_s3_class(sv_importance(x, max_display = 2L), "ggplot")
+  expect_s3_class(sv_importance(x, max_display = 2L, show_numbers = TRUE), "ggplot")
+})
+
+# SHAP interactions
+x_inter <- shapviz(fit, X_pred = dtrain, X = iris[, -1L], interactions = TRUE)
+
+test_that("dependence plots work for interactions = TRUE", {
+  expect_s3_class(
+    sv_dependence(x_inter, v = "Petal.Length", interactions = TRUE),
+    "ggplot"
+  )
+  expect_s3_class(
+    sv_dependence(x_inter, v = c("Petal.Length", "Species"), interactions = TRUE),
+    "patchwork"
+  )
+  expect_s3_class(
+    sv_dependence(
+      x_inter,
+      v = "Species",
+      color_var = c("Petal.Length", "Species"),
+      interactions = TRUE
+    ),
+    "patchwork"
+  )
+
+  expect_s3_class(
+    sv_dependence(x_inter, "Petal.Length", color_var = "Species", interactions = TRUE),
+    "ggplot"
+  )
+  expect_s3_class(
+    sv_dependence(
+      x_inter,
+      v = c("Petal.Length", "Species"),
+      color_var = "Species",
+      interactions = TRUE
+    ),
+    "patchwork"
+  )
+
+  expect_s3_class(
+    sv_dependence2D(x_inter, x = "Petal.Length", y = "Species", interactions = TRUE),
+    "ggplot"
+  )
+  expect_s3_class(
+    sv_dependence2D(
+      x_inter, x = "Petal.Length", y = c("Species", "Petal.Width"), interactions = TRUE
+    ),
+    "patchwork"
+  )
+  expect_s3_class(
+    sv_dependence2D(
+      x_inter, x = c("Petal.Length", "Petal.Width"), y = "Species", interactions = TRUE
+    ),
+    "patchwork"
+  )
+  expect_s3_class(
+    sv_dependence2D(
+      x_inter,
+      x = c("Petal.Length", "Petal.Width"),
+      y = c("Species", "Sepal.Width"),
+      interactions = TRUE
+    ),
+    "patchwork"
+  )
+})
+
+test_that("main effect plots equal case color_var = v", {
+  expect_equal(
+    sv_dependence(x_inter, "Petal.Length", color_var = NULL, interactions = TRUE),
+    sv_dependence(
+      x_inter, "Petal.Length", color_var = "Petal.Length", interactions = TRUE
+    )
+  )
+})
+
+test_that("Interaction plots provide ggplot object", {
+  expect_s3_class(sv_interaction(x_inter), "ggplot")
+})
+
+# Non-standard name
+ir <- iris
+ir["strange name"] <- ir$Sepal.Width * ir$Petal.Length
+dtrain <- xgboost::xgb.DMatrix(data.matrix(ir[, -1L]), label = ir[, 1L])
+fit <- xgboost::xgb.train(params = list(nthread = 1L), data = dtrain, nrounds = 1L)
+x <- shapviz(fit, X_pred = dtrain, X = ir[, -1L])
+
+test_that("plots work for non-syntactic column names", {
+  expect_s3_class(sv_waterfall(x, 2), "ggplot")
+  expect_s3_class(sv_force(x, 2), "ggplot")
+  expect_s3_class(sv_importance(x), "ggplot")
+  expect_s3_class(sv_importance(x, show_numbers = TRUE), "ggplot")
+  expect_s3_class(sv_importance(x, max_display = 2, kind = "beeswarm"), "ggplot")
+  expect_s3_class(sv_importance(x, kind = "beeswarm"), "ggplot")
+  expect_s3_class(sv_dependence(x, "strange name"), "ggplot")
+  expect_s3_class(
+    sv_dependence(x, "Petal.Length", color_var = "strange name"), "ggplot"
+  )
+  expect_s3_class(
+    sv_dependence2D(x, x = "Petal.Length", y = "strange name"), "ggplot"
+  )
+})
+
+# Miscellaneous tests
+test_that("there are no default sv_*() methods", {
+  for (f in c(
+    sv_dependence,
+    sv_dependence2D,
+    sv_importance,
+    sv_force,
+    sv_waterfall,
+    sv_interaction
+  )) {
+    expect_error(f(1))
+  }
+})
+
+test_that("sv_importance() and sv_interaction() and kind = 'no' gives numeric output", {
+  X_pred <- data.matrix(iris[, -1L])
+  dtrain <- xgboost::xgb.DMatrix(X_pred, label = iris[, 1L])
+  fit <- xgboost::xgb.train(params = list(nthread = 1L), data = dtrain, nrounds = 1L)
+  x <- shapviz(fit, X_pred = X_pred, interactions = TRUE)
+
+  imp <- sv_importance(x, kind = "no")
+  expect_true(is.numeric(imp) && length(imp) == ncol(X_pred))
+
+  inter <- sv_interaction(x, kind = "no")
+  expect_true(is.numeric(inter) && all(dim(inter) == rep(ncol(X_pred), 2L)))
+})
+

--- a/vignettes/multiple_output.Rmd
+++ b/vignettes/multiple_output.Rmd
@@ -22,10 +22,10 @@ knitr::opts_chunk$set(
 
 ## Overview
 
-Sometimes, you will find it necessary to work with several "shapviz" objects at the same time:
+Sometimes, you will find it necessary to work with several compatible "shapviz" objects at the same time:
 
 - To visualize SHAP values of a multiclass or multi-output model.
-- To compare SHAP plots of different models.
+- To compare SHAP plots of different models (with identical features).
 - To compare SHAP plots between subgroups.
 
 To simplify the workflow, {shapviz} introduces the "mshapviz" object ("m" like "multi"). You can create it in different ways:


### PR DESCRIPTION
- shapviz objects now need to have the same column names when combined to a "mshapviz" object. This helps to simplify certain plots and checks.