### PR TITLE
Set `drop = TRUE` in `split.shapviz()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,11 @@
 - `print.shapviz()` now shows top two rows of SHAP matrix.
 - Re-activate all unit tests.
 - Added "How to contribute" to README.
-- `sv_dependence2D()`: In case `add_vars` are passed, `x` and/or `y` are removed from it in order to not use any variable twice.
+
+## Bug fixes
+
+- `sv_dependence2D()`: In case `add_vars` are passed, `x` and/or `y` are removed from it in order to not use any variable twice [#116](https://github.com/ModelOriented/shapviz/pull/116).
+- `split.shapviz()` now drops empty levels. They launched an error because empty "shapviz" objects are currently not supported.
 
 # shapviz 0.9.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,8 +13,8 @@
 
 ## Bug fixes
 
-- `sv_dependence2D()`: In case `add_vars` are passed, `x` and/or `y` are removed from it in order to not use any variable twice [#116](https://github.com/ModelOriented/shapviz/pull/116).
-- `split.shapviz()` now drops empty levels. They launched an error because empty "shapviz" objects are currently not supported.
+- `sv_dependence2D()`: In case `add_vars` are passed, `x` and/or `y` are removed from it in order to not use any variable twice. [#116](https://github.com/ModelOriented/shapviz/pull/116).
+- `split.shapviz()` now drops empty levels. They launched an error because empty "shapviz" objects are currently not supported. [#117](https://github.com/ModelOriented/shapviz/pull/117)
 
 # shapviz 0.9.2
 

--- a/R/methods.R
+++ b/R/methods.R
@@ -354,7 +354,8 @@ c.shapviz <- function(...) {
 #'
 #' @param x Object of class "shapviz".
 #' @param f Vector used to split feature values and SHAP (interaction) values.
-#' @param ... Arguments passed to `split()`.
+#' @param ... Arguments passed to `split()`. Don't pass `drop = TRUE` as empty
+#'   "shapviz" objects are rejected.
 #' @returns A "mshapviz" object.
 #' @examples
 #' \dontrun{
@@ -367,7 +368,7 @@ c.shapviz <- function(...) {
 #' @export
 #' @seealso [shapviz()], [rbind.shapviz()]
 split.shapviz <- function(x, f, ...) {
-  ind <- split(seq_len(nrow(x)), f = f, ...)
+  ind <- split(seq_len(nrow(x)), f = f, drop = FALSE, ...)
   mshapviz(lapply(ind, function(i) x[i, ]))
 }
 

--- a/man/split.shapviz.Rd
+++ b/man/split.shapviz.Rd
@@ -11,7 +11,8 @@
 
 \item{f}{Vector used to split feature values and SHAP (interaction) values.}
 
-\item{...}{Arguments passed to \code{split()}.}
+\item{...}{Arguments passed to \code{split()}. Don't pass \code{drop = TRUE} as empty
+"shapviz" objects are rejected.}
 }
 \value{
 A "mshapviz" object.


### PR DESCRIPTION
Splitting on an empty factor level does not work with `split.shapviz(). Setting `drop = TRUE` to fix the problem.