### PR TITLE
permshap() has been integrated into kernelshap package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,13 +10,12 @@ Description: Visualizations for SHAP (SHapley Additive exPlanations), such
     dependence plots, and interaction plots.  These plots act on a
     'shapviz' object created from a matrix of SHAP values and a
     corresponding feature dataset. Wrappers for the R packages 'xgboost',
-    'lightgbm', 'fastshap', 'shapr', 'h2o', 'treeshap', 'DALEX',
-    'kernelshap', and 'permshap' are added for convenience.  By separating
-    visualization and computation, it is possible to display factor
-    variables in graphs, even if the SHAP values are calculated by a model
-    that requires numerical features. The plots are inspired by those
-    provided by the 'shap' package in Python, but there is no dependency
-    on it.
+    'lightgbm', 'fastshap', 'shapr', 'h2o', 'treeshap', 'DALEX', and
+    'kernelshap' are added for convenience.  By separating visualization
+    and computation, it is possible to display factor variables in graphs,
+    even if the SHAP values are calculated by a model that requires
+    numerical features. The plots are inspired by those provided by the
+    'shap' package in Python, but there is no dependency on it.
 License: GPL (>= 2)
 Depends: 
     R (>= 3.6.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 - `print.shapviz()` now shows top two rows of SHAP matrix.
 - Re-activate all unit tests.
 - Added "How to contribute" to README.
+- `permshap()` connector is now part of {kerneshap}.
 
 ## Bug fixes
 

--- a/R/shapviz.R
+++ b/R/shapviz.R
@@ -13,7 +13,7 @@
 #' - `treeshap::treeshap()`,
 #' - `DALEX::predict_parts()`,
 #' - `kernelshap::kernelshap()`, and
-#' - `permshap::permshap()`,
+#' - `kernelshap::permshap()`,
 #'
 #' check the vignettes for examples.
 #'
@@ -413,7 +413,7 @@ shapviz.kernelshap <- function(object, X = object[["X"]],
 }
 
 #' @describeIn shapviz
-#'   Creates a "shapviz" object from `permshap::permshap()`.
+#'   Creates a "shapviz" object from `kernelshap::permshap()`.
 #' @export
 shapviz.permshap <- function(object, X = object[["X"]],
                              which_class = NULL, collapse = NULL, ...) {

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ To further simplify the use of {shapviz}, we added direct connectors to:
 - [`shapr`](https://CRAN.R-project.org/package=shapr)
 - [`treeshap`](https://CRAN.R-project.org/package=treeshap)
 - [`DALEX`](https://CRAN.R-project.org/package=DALEX)
-- [`permshap`](https://github.com/mayer79/permshap)
 
 For XGBoost, LightGBM, and H2O, the SHAP values are directly calculated from the fitted model.
 

--- a/man/shapviz-package.Rd
+++ b/man/shapviz-package.Rd
@@ -8,7 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-Visualizations for SHAP (SHapley Additive exPlanations), such as waterfall plots, force plots, various types of importance plots, dependence plots, and interaction plots. These plots act on a 'shapviz' object created from a matrix of SHAP values and a corresponding feature dataset. Wrappers for the R packages 'xgboost', 'lightgbm', 'fastshap', 'shapr', 'h2o', 'treeshap', 'DALEX', 'kernelshap', and 'permshap' are added for convenience. By separating visualization and computation, it is possible to display factor variables in graphs, even if the SHAP values are calculated by a model that requires numerical features. The plots are inspired by those provided by the 'shap' package in Python, but there is no dependency on it.
+Visualizations for SHAP (SHapley Additive exPlanations), such as waterfall plots, force plots, various types of importance plots, dependence plots, and interaction plots. These plots act on a 'shapviz' object created from a matrix of SHAP values and a corresponding feature dataset. Wrappers for the R packages 'xgboost', 'lightgbm', 'fastshap', 'shapr', 'h2o', 'treeshap', 'DALEX', and 'kernelshap' are added for convenience. By separating visualization and computation, it is possible to display factor variables in graphs, even if the SHAP values are calculated by a model that requires numerical features. The plots are inspired by those provided by the 'shap' package in Python, but there is no dependency on it.
 }
 \seealso{
 Useful links:

--- a/man/shapviz.Rd
+++ b/man/shapviz.Rd
@@ -123,7 +123,7 @@ Furthermore, \code{\link[=shapviz]{shapviz()}} can digest the results of
 \item \code{treeshap::treeshap()},
 \item \code{DALEX::predict_parts()},
 \item \code{kernelshap::kernelshap()}, and
-\item \code{permshap::permshap()},
+\item \code{kernelshap::permshap()},
 }
 
 check the vignettes for examples.
@@ -161,7 +161,7 @@ return a "mshapviz" object, containing a "shapviz" object per output.
 
 \item \code{shapviz(kernelshap)}: Creates a "shapviz" object from \code{kernelshap::kernelshap()}.
 
-\item \code{shapviz(permshap)}: Creates a "shapviz" object from \code{permshap::permshap()}.
+\item \code{shapviz(permshap)}: Creates a "shapviz" object from \code{kernelshap::permshap()}.
 
 \item \code{shapviz(H2ORegressionModel)}: Creates a "shapviz" object from a (tree-based) H2O regression model.
 

--- a/packaging.R
+++ b/packaging.R
@@ -22,7 +22,7 @@ use_description(
     These plots act on a 'shapviz' object created from a matrix of SHAP
     values and a corresponding feature dataset. Wrappers for the R packages
     'xgboost', 'lightgbm', 'fastshap', 'shapr', 'h2o', 'treeshap', 'DALEX',
-    'kernelshap', and 'permshap' are added for convenience.
+    and 'kernelshap' are added for convenience.
     By separating visualization and computation, it is possible to display
     factor variables in graphs, even if the SHAP values are calculated by a model
     that requires numerical features. The plots are inspired by those provided by
@@ -45,7 +45,6 @@ use_package("ggfittext", "Imports", min_version = "0.8.0")
 use_package("ggrepel", "Imports")
 use_package("patchwork", "Imports")
 use_package("xgboost", "Imports")
-use_package("data.table", "Imports")
 
 use_package("fastshap", "Enhances")
 use_package("h2o", "Enhances")
@@ -61,14 +60,13 @@ use_build_ignore(c("^packaging.R$", "[.]Rproj$", "^logo.png$"), escape = FALSE)
 
 # If your package contains data. Google how to document
 # miami <- OpenML::getOMLDataSet(43093)$data
-use_data(miami)
+use_data(miami, overwrite = TRUE)
 
 # Add short docu in Markdown (without running R code)
 use_readme_md()
 
 # Longer docu in RMarkdown (with running R code). Often quite similar to readme.
 use_vignette("basic_use")
-use_vignette("multiple_output")
 
 # If you want to add unit tests
 use_testthat()
@@ -85,9 +83,6 @@ use_logo("logo.png")
 use_cran_comments()
 
 use_github_links(overwrite = TRUE) # use this if this project is on github
-
-# Build website
-# use_pkgdown(config_file = "pkgdown/_pkgdown.yml")
 
 # Github actions
 # use_github_action("check-standard")

--- a/vignettes/basic_use.Rmd
+++ b/vignettes/basic_use.Rmd
@@ -51,7 +51,6 @@ To further simplify the use of {shapviz}, we added direct connectors to:
 - [`shapr`](https://CRAN.R-project.org/package=shapr)
 - [`treeshap`](https://CRAN.R-project.org/package=treeshap)
 - [`DALEX`](https://CRAN.R-project.org/package=DALEX)
-- [`permshap`](https://github.com/mayer79/permshap) (not on CRAN)
 
 For XGBoost, LightGBM, and H2O, the SHAP values are directly calculated from the fitted model.
 
@@ -328,28 +327,17 @@ sv_force(shapviz(breakdown)) +
 
 ### kernelshap
 
+Either using `kernelshap()` or `permshap()`:
+
 ```r
 library(kernelshap)
 
 background <- diamonds[sample(nrow(diamonds), 200), ]
 fit <- lm(price ~ carat + clarity + cut + color, data = diamonds)
 ks <- kernelshap(fit, dia_small[x], bg_X = background)
+# ks <- permshap(fit, dia_small[x], bg_X = background)
 
 shp <- shapviz(ks)
-sv_importance(shp)
-sv_dependence(shp, "carat", color_var = NULL)
-```
-
-### permshap
-
-```r
-library(permshap)
-
-background <- diamonds[sample(nrow(diamonds), 200), ]
-fit <- lm(price ~ carat + clarity + cut + color, data = diamonds)
-ps <- permshap(fit, dia_small[x], bg_X = background)
-
-shp <- shapviz(ps)
 sv_importance(shp)
 sv_dependence(shp, "carat", color_var = NULL)
 ```


### PR DESCRIPTION
The `permshap()` function is now integrated into the {kernelshap} package. This requires small changes in the documentation of {shapviz}.