### PR TITLE
Collect axes, axis titles, and guides

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,19 +1,17 @@
 # shapviz 0.10.0
 
-### New feature
+### New visualization
 
 `sv_interaction()`: New `kind = "bar"` to show mean absolute SHAP interactions/main effects as barplots.
 Modify via `fill` and `bar_width` arguments [#169](https://github.com/ModelOriented/shapviz/pull/169).
 
 ### User-visible changes
 
-- Collecting color guides: We now use {patchwork} to collect color guides in 
-  `sv_importance()` and `sv_interaction()` when applied to "mshapviz" objects.
-  This affects the beeswarm plots.
-- Collecting axis titles: We now use {patchwork} to collect axis titles when
-  applying plot functions to an "mshapviz" object, except for `sv_dependence()`
-  (where we need a more sophisticated logic). Currently does not work for `sv_force()`.
-- `sv_dependence2D()`: The color guide is less wide.
+- We are now (cautiously) collecting axes, axis titles, and color guides via {patchwork}. (Currently fails for `sv_force()`.)
+
+### Minor API changes
+
+- In `sv_dependence()`, passing the same variable for `v` and `color_var` does not suppress the color axis anymore, except when `interactions = TRUE`.
 
 ### Maintenance
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,8 +7,12 @@ Modify via `fill` and `bar_width` arguments [#169](https://github.com/ModelOrien
 
 ### User-visible changes
 
-- `sv_interaction()`: If applied to a "mshapviz" object, we use {patchwork} functionality to collect guides and axis titles.
-
+- Collecting color guides: We now use {patchwork} to collect color guides in 
+  `sv_importance()` and `sv_interaction()` when applied to "mshapviz" objects.
+  This affects the beeswarm plots.
+- Collecting axis titles: We now use {patchwork} to collect axis titles when
+  applying plot functions to an "mshapviz" object, except for `sv_dependence()`
+  (where we need a more sophisticated logic). Currently does not work for `sv_force()`.
 
 ### Maintenance
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ Modify via `fill` and `bar_width` arguments [#169](https://github.com/ModelOrien
 - Collecting axis titles: We now use {patchwork} to collect axis titles when
   applying plot functions to an "mshapviz" object, except for `sv_dependence()`
   (where we need a more sophisticated logic). Currently does not work for `sv_force()`.
+- `sv_dependence2D()`: The color guide is less wide.
 
 ### Maintenance
 

--- a/R/sv_dependence2D.R
+++ b/R/sv_dependence2D.R
@@ -199,10 +199,15 @@ sv_dependence2D.mshapviz <- function(
   if (is.null(viridis_args)) {
     viridis_args <- list()
   }
-  p <- ggplot2::ggplot(dat, ggplot2::aes(x = .data[[x]], y = .data[[y]], color = SHAP)) +
+  p <- ggplot2::ggplot(
+    dat, ggplot2::aes(x = .data[[x]], y = .data[[y]], color = SHAP)
+  ) +
     ggplot2::geom_jitter(width = jitter_width, height = jitter_height, ...) +
     do.call(vir, viridis_args) +
-    ggplot2::theme(legend.box.spacing = grid::unit(0, "pt"))
+    ggplot2::theme(
+      legend.box.spacing = grid::unit(0, "pt"),
+      legend.key.width = grid::unit(12, "pt")
+    )
 
   return(p)
 }

--- a/R/sv_dependence2D.R
+++ b/R/sv_dependence2D.R
@@ -30,7 +30,8 @@
 #' @returns An object of class "ggplot" (or "patchwork") representing a dependence plot.
 #' @examples
 #' dtrain <- xgboost::xgb.DMatrix(
-#'   data.matrix(iris[, -1]), label = iris[, 1], nthread = 1
+#'   data.matrix(iris[, -1]),
+#'   label = iris[, 1], nthread = 1
 #' )
 #' fit <- xgboost::xgb.train(data = dtrain, nrounds = 10, nthread = 1)
 #' sv <- shapviz(fit, X_pred = dtrain, X = iris)
@@ -41,7 +42,8 @@
 #' sv2 <- shapviz(fit, X_pred = dtrain, X = iris, interactions = TRUE)
 #' sv_dependence2D(sv2, x = "Petal.Length", y = "Species", interactions = TRUE)
 #' sv_dependence2D(
-#'   sv2, x = "Petal.Length", y = c("Species", "Petal.Width"), interactions = TRUE
+#'   sv2,
+#'   x = "Petal.Length", y = c("Species", "Petal.Width"), interactions = TRUE
 #' )
 #'
 #' # mshapviz object
@@ -63,10 +65,16 @@ sv_dependence2D.default <- function(object, ...) {
 #' @describeIn sv_dependence2D
 #'   2D SHAP dependence plot for "shapviz" object.
 #' @export
-sv_dependence2D.shapviz <- function(object, x, y,
-                                    viridis_args = getOption("shapviz.viridis_args"),
-                                    jitter_width = NULL, jitter_height = NULL,
-                                    interactions = FALSE, add_vars = NULL, ...) {
+sv_dependence2D.shapviz <- function(
+    object,
+    x,
+    y,
+    viridis_args = getOption("shapviz.viridis_args"),
+    jitter_width = NULL,
+    jitter_height = NULL,
+    interactions = FALSE,
+    add_vars = NULL,
+    ...) {
   p <- max(length(x), length(y))
   if (p > 1L) {
     if (is.null(jitter_width)) {
@@ -115,11 +123,11 @@ sv_dependence2D.shapviz <- function(object, x, y,
 
   # Color variable
   if (!interactions) {
-    s <- rowSums(S[, unique(c(x, y, add_vars))])  # unique() if add_vars contains x or y
+    s <- rowSums(S[, unique(c(x, y, add_vars))]) # unique() if add_vars contains x or y
   } else {
     s <- S_inter[, x, y]
     if (x != y) {
-      s <- 2 * s  # Off-diagonals need to be multiplied by 2 for symmetry reasons
+      s <- 2 * s # Off-diagonals need to be multiplied by 2 for symmetry reasons
     }
   }
   dat <- data.frame(SHAP = s, X[, c(x, y)], check.names = FALSE)
@@ -136,10 +144,16 @@ sv_dependence2D.shapviz <- function(object, x, y,
 #' @describeIn sv_dependence2D
 #'   2D SHAP dependence plot for "mshapviz" object.
 #' @export
-sv_dependence2D.mshapviz <- function(object, x, y,
-                                     viridis_args = getOption("shapviz.viridis_args"),
-                                     jitter_width = NULL, jitter_height = NULL,
-                                     interactions = FALSE, add_vars = NULL, ...) {
+sv_dependence2D.mshapviz <- function(
+    object,
+    x,
+    y,
+    viridis_args = getOption("shapviz.viridis_args"),
+    jitter_width = NULL,
+    jitter_height = NULL,
+    interactions = FALSE,
+    add_vars = NULL,
+    ...) {
   stopifnot(
     length(x) == 1L,
     length(y) == 1L
@@ -157,7 +171,6 @@ sv_dependence2D.mshapviz <- function(object, x, y,
     add_vars = add_vars,
     ...
   )
-  plot_list <- add_titles(plot_list, nms = names(object))  # see sv_waterfall()
+  plot_list <- add_titles(plot_list, nms = names(object)) # see sv_waterfall()
   patchwork::wrap_plots(plot_list)
 }
-

--- a/R/sv_dependence2D.R
+++ b/R/sv_dependence2D.R
@@ -75,13 +75,13 @@ sv_dependence2D.shapviz <- function(
     interactions = FALSE,
     add_vars = NULL,
     ...) {
-  p <- max(length(x), length(y))
-  if (p > 1L) {
+  nvars <- max(length(x), length(y))
+  if (nvars > 1L) {
     if (is.null(jitter_width)) {
-      jitter_width <- replicate(p, NULL)
+      jitter_width <- replicate(nvars, NULL)
     }
     if (is.null(jitter_height)) {
-      jitter_height <- replicate(p, NULL)
+      jitter_height <- replicate(nvars, NULL)
     }
     plot_list <- mapply(
       FUN = sv_dependence2D,

--- a/R/sv_dependence2D.R
+++ b/R/sv_dependence2D.R
@@ -172,5 +172,6 @@ sv_dependence2D.mshapviz <- function(
     ...
   )
   plot_list <- add_titles(plot_list, nms = names(object)) # see sv_waterfall()
-  patchwork::wrap_plots(plot_list)
+  p <- patchwork::wrap_plots(plot_list, axis_titles = "collect")
+  return(p)
 }

--- a/R/sv_force.R
+++ b/R/sv_force.R
@@ -176,7 +176,7 @@ sv_force.mshapviz <- function(
   )
   plot_list <- add_titles(plot_list, nms = names(object)) # see sv_waterfall()
 
-  # Currently, collecting x axes titles does not work
+  # Currently, collecting axes titles does not work (but sv_waterfall() is ok)
   p <- patchwork::wrap_plots(plot_list, ncol = 1L, axis_titles = "collect")
   return(p)
 }

--- a/R/sv_force.R
+++ b/R/sv_force.R
@@ -12,7 +12,8 @@
 #' @returns An object of class "ggplot" (or "patchwork") representing a force plot.
 #' @examples
 #' dtrain <- xgboost::xgb.DMatrix(
-#'   data.matrix(iris[, -1]), label = iris[, 1], nthread = 1
+#'   data.matrix(iris[, -1]),
+#'   label = iris[, 1], nthread = 1
 #' )
 #' fit <- xgboost::xgb.train(data = dtrain, nrounds = 20, nthread = 1)
 #' x <- shapviz(fit, X_pred = dtrain, X = iris[, -1])
@@ -37,12 +38,18 @@ sv_force.default <- function(object, ...) {
 #' @describeIn sv_force
 #'   SHAP force plot for object of class "shapviz".
 #' @export
-sv_force.shapviz <- function(object, row_id = 1L, max_display = 6L,
-                             fill_colors = c("#f7d13d", "#a52c60"),
-                             format_shap = getOption("shapviz.format_shap"),
-                             format_feat = getOption("shapviz.format_feat"),
-                             contrast = TRUE, bar_label_size = 3.2,
-                             show_annotation = TRUE, annotation_size = 3.2, ...) {
+sv_force.shapviz <- function(
+    object,
+    row_id = 1L,
+    max_display = 6L,
+    fill_colors = c("#f7d13d", "#a52c60"),
+    format_shap = getOption("shapviz.format_shap"),
+    format_feat = getOption("shapviz.format_feat"),
+    contrast = TRUE,
+    bar_label_size = 3.2,
+    show_annotation = TRUE,
+    annotation_size = 3.2,
+    ...) {
   stopifnot(
     "Exactly two fill colors must be passed" = length(fill_colors) == 2L,
     "format_shap must be a function" = is.function(format_shap),
@@ -140,12 +147,18 @@ sv_force.shapviz <- function(object, row_id = 1L, max_display = 6L,
 #' @describeIn sv_force
 #'   SHAP force plot for object of class "mshapviz".
 #' @export
-sv_force.mshapviz <- function(object, row_id = 1L, max_display = 6L,
-                              fill_colors = c("#f7d13d", "#a52c60"),
-                              format_shap = getOption("shapviz.format_shap"),
-                              format_feat = getOption("shapviz.format_feat"),
-                              contrast = TRUE, bar_label_size = 3.2,
-                              show_annotation = TRUE, annotation_size = 3.2, ...) {
+sv_force.mshapviz <- function(
+    object,
+    row_id = 1L,
+    max_display = 6L,
+    fill_colors = c("#f7d13d", "#a52c60"),
+    format_shap = getOption("shapviz.format_shap"),
+    format_feat = getOption("shapviz.format_feat"),
+    contrast = TRUE,
+    bar_label_size = 3.2,
+    show_annotation = TRUE,
+    annotation_size = 3.2,
+    ...) {
   plot_list <- lapply(
     object,
     FUN = sv_force,
@@ -161,7 +174,9 @@ sv_force.mshapviz <- function(object, row_id = 1L, max_display = 6L,
     annotation_size = annotation_size,
     ...
   )
-  plot_list <- add_titles(plot_list, nms = names(object))  # see sv_waterfall()
-  patchwork::wrap_plots(plot_list) +
-    patchwork::plot_layout(ncol = 1L)
+  plot_list <- add_titles(plot_list, nms = names(object)) # see sv_waterfall()
+
+  # Currently, collecting x axes titles does not work
+  p <- patchwork::wrap_plots(plot_list, ncol = 1L, axis_titles = "collect")
+  return(p)
 }

--- a/R/sv_force.R
+++ b/R/sv_force.R
@@ -177,6 +177,6 @@ sv_force.mshapviz <- function(
   plot_list <- add_titles(plot_list, nms = names(object)) # see sv_waterfall()
 
   # Currently, collecting axes titles does not work (but sv_waterfall() is ok)
-  p <- patchwork::wrap_plots(plot_list, ncol = 1L, axis_titles = "collect")
+  p <- patchwork::wrap_plots(plot_list, ncol = 1L, axis_titles = "collect_x")
   return(p)
 }

--- a/R/sv_importance.R
+++ b/R/sv_importance.R
@@ -70,13 +70,21 @@ sv_importance.default <- function(object, ...) {
 #' @describeIn sv_importance
 #'   SHAP importance plot for an object of class "shapviz".
 #' @export
-sv_importance.shapviz <- function(object, kind = c("bar", "beeswarm", "both", "no"),
-                                  max_display = 15L, fill = "#fca50a", bar_width = 2/3,
-                                  bee_width = 0.4, bee_adjust = 0.5,
-                                  viridis_args = getOption("shapviz.viridis_args"),
-                                  color_bar_title = "Feature value",
-                                  show_numbers = FALSE, format_fun = format_max,
-                                  number_size = 3.2, sort_features = TRUE, ...) {
+sv_importance.shapviz <- function(
+    object,
+    kind = c("bar", "beeswarm", "both", "no"),
+    max_display = 15L,
+    fill = "#fca50a",
+    bar_width = 2 / 3,
+    bee_width = 0.4,
+    bee_adjust = 0.5,
+    viridis_args = getOption("shapviz.viridis_args"),
+    color_bar_title = "Feature value",
+    show_numbers = FALSE,
+    format_fun = format_max,
+    number_size = 3.2,
+    sort_features = TRUE,
+    ...) {
   stopifnot("format_fun must be a function" = is.function(format_fun))
   kind <- match.arg(kind)
   imp <- .get_imp(get_shap_values(object), sort_features = sort_features)
@@ -90,7 +98,7 @@ sv_importance.shapviz <- function(object, kind = c("bar", "beeswarm", "both", "n
     imp <- imp[seq_len(max_display)]
   }
   ord <- names(imp)
-  object <- object[, ord]  # not required for kind = "bar"
+  object <- object[, ord] # not required for kind = "bar"
 
   # ggplot will need to work with data.frame
   imp_df <- data.frame(feature = factor(ord, rev(ord)), value = imp)
@@ -126,7 +134,7 @@ sv_importance.shapviz <- function(object, kind = c("bar", "beeswarm", "both", "n
       .get_color_scale(
         viridis_args = viridis_args,
         bar = !is.null(color_bar_title),
-        ncol = length(unique(df$color))   # Special case of constant feature values
+        ncol = length(unique(df$color)) # Special case of constant feature values
       ) +
       ggplot2::labs(
         x = "SHAP value", y = ggplot2::element_blank(), color = color_bar_title
@@ -138,15 +146,18 @@ sv_importance.shapviz <- function(object, kind = c("bar", "beeswarm", "both", "n
       ggplot2::geom_text(
         data = imp_df,
         ggplot2::aes(
-          x = if (is_bar) value + max(value) / 60 else
-            min(df$value) - diff(range(df$value)) / 20,
+          x = if (is_bar) {
+            value + max(value) / 60
+          } else {
+            min(df$value) - diff(range(df$value)) / 20
+          },
           label = format_fun(value)
         ),
         hjust = !is_bar,
         size = number_size
       ) +
       ggplot2::scale_x_continuous(
-        expand = ggplot2::expansion(mult = 0.05 + c(0.12 *!is_bar, 0.09 * is_bar))
+        expand = ggplot2::expansion(mult = 0.05 + c(0.12 * !is_bar, 0.09 * is_bar))
       )
   }
   p
@@ -155,15 +166,22 @@ sv_importance.shapviz <- function(object, kind = c("bar", "beeswarm", "both", "n
 #' @describeIn sv_importance
 #'   SHAP importance plot for an object of class "mshapviz".
 #' @export
-sv_importance.mshapviz <- function(object, kind = c("bar", "beeswarm", "both", "no"),
-                                   max_display = 15L, fill = "#fca50a",
-                                   bar_width = 2/3,
-                                   bar_type = c("dodge", "stack", "facets", "separate"),
-                                   bee_width = 0.4, bee_adjust = 0.5,
-                                   viridis_args = getOption("shapviz.viridis_args"),
-                                   color_bar_title = "Feature value",
-                                   show_numbers = FALSE, format_fun = format_max,
-                                   number_size = 3.2, sort_features = TRUE, ...) {
+sv_importance.mshapviz <- function(
+    object,
+    kind = c("bar", "beeswarm", "both", "no"),
+    max_display = 15L,
+    fill = "#fca50a",
+    bar_width = 2 / 3,
+    bar_type = c("dodge", "stack", "facets", "separate"),
+    bee_width = 0.4,
+    bee_adjust = 0.5,
+    viridis_args = getOption("shapviz.viridis_args"),
+    color_bar_title = "Feature value",
+    show_numbers = FALSE,
+    format_fun = format_max,
+    number_size = 3.2,
+    sort_features = TRUE,
+    ...) {
   kind <- match.arg(kind)
   bar_type <- match.arg(bar_type)
 
@@ -197,7 +215,7 @@ sv_importance.mshapviz <- function(object, kind = c("bar", "beeswarm", "both", "
         ggplot2::labs(fill = ggplot2::element_blank()) +
         do.call(ggplot2::scale_fill_viridis_d, viridis_args) +
         ggplot2::guides(fill = ggplot2::guide_legend(reverse = TRUE))
-    } else {  # facets
+    } else { # facets
       p <- ggplot2::ggplot(imp_df, ggplot2::aes(x = values, y = feature)) +
         ggplot2::geom_bar(fill = fill, width = bar_width, stat = "identity", ...) +
         ggplot2::facet_wrap("ind")
@@ -230,8 +248,9 @@ sv_importance.mshapviz <- function(object, kind = c("bar", "beeswarm", "both", "
   if (kind == "no") {
     return(plot_list)
   }
-  plot_list <- add_titles(plot_list, nms = names(object))  # see sv_waterfall()
-  patchwork::wrap_plots(plot_list)
+  plot_list <- add_titles(plot_list, nms = names(object)) # see sv_waterfall()
+  p <- patchwork::wrap_plots(plot_list, guides = "collect", axis_titles = "collect")
+  return(p)
 }
 
 # Helper functions
@@ -242,7 +261,7 @@ sv_importance.mshapviz <- function(object, kind = c("bar", "beeswarm", "both", "
     z[!is.na(z)] <- 0.5
     return(z)
   }
-  (z - r[1L]) /(r[2L] - r[1L])
+  (z - r[1L]) / (r[2L] - r[1L])
 }
 
 .get_imp <- function(z, sort_features = TRUE) {

--- a/R/sv_importance.R
+++ b/R/sv_importance.R
@@ -249,7 +249,7 @@ sv_importance.mshapviz <- function(
     return(plot_list)
   }
   plot_list <- add_titles(plot_list, nms = names(object)) # see sv_waterfall()
-  p <- patchwork::wrap_plots(plot_list, guides = "collect", axis_titles = "collect")
+  p <- patchwork::wrap_plots(plot_list, axis_titles = "collect_x", guides = "collect")
   return(p)
 }
 

--- a/R/sv_interaction.R
+++ b/R/sv_interaction.R
@@ -185,7 +185,7 @@ sv_interaction.mshapviz <- function(
     return(plot_list)
   }
   plot_list <- add_titles(plot_list, nms = names(object)) # see sv_waterfall()
-  p <- patchwork::wrap_plots(plot_list, axis_titles = "collect", guides = "collect")
+  p <- patchwork::wrap_plots(plot_list, axis_titles = "collect_x", guides = "collect")
 
   return(p)
 }

--- a/R/sv_waterfall.R
+++ b/R/sv_waterfall.R
@@ -204,7 +204,7 @@ sv_waterfall.mshapviz <- function(
     ...
   )
   plot_list <- add_titles(plot_list, nms = names(object))
-  p <- patchwork::wrap_plots(plot_list, axis_titles = "collect")
+  p <- patchwork::wrap_plots(plot_list, axis_titles = "collect_x")
   return(p)
 }
 

--- a/R/sv_waterfall.R
+++ b/R/sv_waterfall.R
@@ -36,7 +36,8 @@
 #' @returns An object of class "ggplot" (or "patchwork") representing a waterfall plot.
 #' @examples
 #' dtrain <- xgboost::xgb.DMatrix(
-#'   data.matrix(iris[, -1]), label = iris[, 1], nthread = 1
+#'   data.matrix(iris[, -1]),
+#'   label = iris[, 1], nthread = 1
 #' )
 #' fit <- xgboost::xgb.train(data = dtrain, nrounds = 20, nthread = 1)
 #' x <- shapviz(fit, X_pred = dtrain, X = iris[, -1])
@@ -45,7 +46,8 @@
 #'
 #' # Ordered by colnames(x), combined with max_display
 #' sv_waterfall(
-#'   x[, sort(colnames(x))], order_fun = function(s) length(s):1, max_display = 3
+#'   x[, sort(colnames(x))],
+#'   order_fun = function(s) length(s):1, max_display = 3
 #' )
 #'
 #' # Aggregate over all observations with Petal.Length == 1.4
@@ -66,13 +68,19 @@ sv_waterfall.default <- function(object, ...) {
 #' @describeIn sv_waterfall
 #'   SHAP waterfall plot for an object of class "shapviz".
 #' @export
-sv_waterfall.shapviz <- function(object, row_id = 1L, max_display = 10L,
-                                 order_fun = function(s) order(abs(s)),
-                                 fill_colors = c("#f7d13d", "#a52c60"),
-                                 format_shap = getOption("shapviz.format_shap"),
-                                 format_feat = getOption("shapviz.format_feat"),
-                                 contrast = TRUE, show_connection = TRUE,
-                                 show_annotation = TRUE, annotation_size = 3.2, ...) {
+sv_waterfall.shapviz <- function(
+    object,
+    row_id = 1L,
+    max_display = 10L,
+    order_fun = function(s) order(abs(s)),
+    fill_colors = c("#f7d13d", "#a52c60"),
+    format_shap = getOption("shapviz.format_shap"),
+    format_feat = getOption("shapviz.format_feat"),
+    contrast = TRUE,
+    show_connection = TRUE,
+    show_annotation = TRUE,
+    annotation_size = 3.2,
+    ...) {
   stopifnot(
     "Exactly two fill colors must be passed" = length(fill_colors) == 2L,
     "format_shap must be a function" = is.function(format_shap),
@@ -166,13 +174,19 @@ sv_waterfall.shapviz <- function(object, row_id = 1L, max_display = 10L,
 #' @describeIn sv_waterfall
 #'   SHAP waterfall plot for an object of class "mshapviz".
 #' @export
-sv_waterfall.mshapviz <- function(object, row_id = 1L, max_display = 10L,
-                                  order_fun = function(s) order(abs(s)),
-                                  fill_colors = c("#f7d13d", "#a52c60"),
-                                  format_shap = getOption("shapviz.format_shap"),
-                                  format_feat = getOption("shapviz.format_feat"),
-                                  contrast = TRUE, show_connection = TRUE,
-                                  show_annotation = TRUE, annotation_size = 3.2, ...) {
+sv_waterfall.mshapviz <- function(
+    object,
+    row_id = 1L,
+    max_display = 10L,
+    order_fun = function(s) order(abs(s)),
+    fill_colors = c("#f7d13d", "#a52c60"),
+    format_shap = getOption("shapviz.format_shap"),
+    format_feat = getOption("shapviz.format_feat"),
+    contrast = TRUE,
+    show_connection = TRUE,
+    show_annotation = TRUE,
+    annotation_size = 3.2,
+    ...) {
   plot_list <- lapply(
     object,
     FUN = sv_waterfall,
@@ -190,7 +204,8 @@ sv_waterfall.mshapviz <- function(object, row_id = 1L, max_display = 10L,
     ...
   )
   plot_list <- add_titles(plot_list, nms = names(object))
-  patchwork::wrap_plots(plot_list)
+  p <- patchwork::wrap_plots(plot_list, axis_titles = "collect")
+  return(p)
 }
 
 # Helper functions for sv_waterfall() and sv_force()

--- a/man/sv_dependence.Rd
+++ b/man/sv_dependence.Rd
@@ -72,7 +72,7 @@ use a value of 0.2 in case \code{v} is discrete, and no jitter otherwise.
 Can be a vector/list if \code{v} is a vector.}
 
 \item{interactions}{Should SHAP interaction values be plotted? Default is \code{FALSE}.
-Requires SHAP interaction values. If \code{color_var = NULL} (or it is equal to \code{v}),
+Requires SHAP interaction values. If \code{color_var = NULL} (or is equal to \code{v}),
 the pure main effect of \code{v} is visualized. Otherwise, twice the SHAP interaction
 values between \code{v} and the \code{color_var} are plotted.}
 
@@ -101,7 +101,8 @@ By default, the feature on the color scale is selected via SHAP interactions
 }}
 \examples{
 dtrain <- xgboost::xgb.DMatrix(
-  data.matrix(iris[, -1]), label = iris[, 1], nthread = 1
+  data.matrix(iris[, -1]),
+  label = iris[, 1], nthread = 1
 )
 fit <- xgboost::xgb.train(data = dtrain, nrounds = 10, nthread = 1)
 x <- shapviz(fit, X_pred = dtrain, X = iris)
@@ -115,7 +116,12 @@ sv_dependence(x, "Petal.Width", color_var = c("Species", "Petal.Length"))
 x2 <- shapviz(fit, X_pred = dtrain, X = iris, interactions = TRUE)
 sv_dependence(x2, "Petal.Length", interactions = TRUE)
 sv_dependence(
-  x2, c("Petal.Length", "Species"), color_var = NULL, interactions = TRUE
+  x2, c("Petal.Length", "Species"),
+  color_var = NULL, interactions = TRUE
+)
+sv_dependence(
+  x2, "Petal.Length",
+  color_var = colnames(iris[-1]), interactions = TRUE
 )
 }
 \seealso{

--- a/man/sv_dependence2D.Rd
+++ b/man/sv_dependence2D.Rd
@@ -40,11 +40,9 @@ sv_dependence2D(object, ...)
 
 \item{...}{Arguments passed to \code{\link[ggplot2:geom_jitter]{ggplot2::geom_jitter()}}.}
 
-\item{x}{Feature name for x axis. Can be a vector/list if \code{object} is
-of class "shapviz".}
+\item{x}{Feature name for x axis. Can be a vector if \code{object} is of class "shapviz".}
 
-\item{y}{Feature name for y axis. Can be a vector/list if \code{object} is
-of class "shapviz".}
+\item{y}{Feature name for y axis. Can be a vector if \code{object} is of class "shapviz".}
 
 \item{viridis_args}{List of viridis color scale arguments, see
 \code{?ggplot2::scale_color_viridis_c}. The default points to the global option
@@ -95,7 +93,8 @@ has no effect.
 }}
 \examples{
 dtrain <- xgboost::xgb.DMatrix(
-  data.matrix(iris[, -1]), label = iris[, 1], nthread = 1
+  data.matrix(iris[, -1]),
+  label = iris[, 1], nthread = 1
 )
 fit <- xgboost::xgb.train(data = dtrain, nrounds = 10, nthread = 1)
 sv <- shapviz(fit, X_pred = dtrain, X = iris)
@@ -106,7 +105,8 @@ sv_dependence2D(sv, x = c("Petal.Length", "Species"), y = "Sepal.Width")
 sv2 <- shapviz(fit, X_pred = dtrain, X = iris, interactions = TRUE)
 sv_dependence2D(sv2, x = "Petal.Length", y = "Species", interactions = TRUE)
 sv_dependence2D(
-  sv2, x = "Petal.Length", y = c("Species", "Petal.Width"), interactions = TRUE
+  sv2,
+  x = "Petal.Length", y = c("Species", "Petal.Width"), interactions = TRUE
 )
 
 # mshapviz object

--- a/man/sv_force.Rd
+++ b/man/sv_force.Rd
@@ -97,7 +97,8 @@ baseline SHAP value.
 }}
 \examples{
 dtrain <- xgboost::xgb.DMatrix(
-  data.matrix(iris[, -1]), label = iris[, 1], nthread = 1
+  data.matrix(iris[, -1]),
+  label = iris[, 1], nthread = 1
 )
 fit <- xgboost::xgb.train(data = dtrain, nrounds = 20, nthread = 1)
 x <- shapviz(fit, X_pred = dtrain, X = iris[, -1])

--- a/man/sv_waterfall.Rd
+++ b/man/sv_waterfall.Rd
@@ -103,7 +103,8 @@ baseline SHAP value.
 }}
 \examples{
 dtrain <- xgboost::xgb.DMatrix(
-  data.matrix(iris[, -1]), label = iris[, 1], nthread = 1
+  data.matrix(iris[, -1]),
+  label = iris[, 1], nthread = 1
 )
 fit <- xgboost::xgb.train(data = dtrain, nrounds = 20, nthread = 1)
 x <- shapviz(fit, X_pred = dtrain, X = iris[, -1])
@@ -112,7 +113,8 @@ sv_waterfall(x, row_id = 123, max_display = 2, size = 9, fill_colors = 4:5)
 
 # Ordered by colnames(x), combined with max_display
 sv_waterfall(
-  x[, sort(colnames(x))], order_fun = function(s) length(s):1, max_display = 3
+  x[, sort(colnames(x))],
+  order_fun = function(s) length(s):1, max_display = 3
 )
 
 # Aggregate over all observations with Petal.Length == 1.4


### PR DESCRIPTION
All plots that use {patchwork} now (cautiously) collect axis titles, axes, and color guides.

This implements and extends https://github.com/ModelOriented/shapviz/issues/161